### PR TITLE
Fix Dockerfile for aarch64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && apt-get install -y \
     virtualenvwrapper python3-dev python3-pip python-is-python3 python3-venv \
     clang-15 lld-15 \
     qemu-user \
-    gcc-multilib \
+    "$( [ "$(uname -m )" = "aarch64" ] && echo cmake )" \
+    "$( [ "$(uname -m )" = "x86_64" ] && echo gcc-multilib )" \
     libc6-armhf-cross libc6-arm64-cross \
     libc6-mips-cross libc6-mips64-cross \
     libc6-powerpc-cross libc6-powerpc-ppc64-cross \


### PR DESCRIPTION
keystone needs cmake to compile its shared object on aarch64
gcc-multilib only exists on x86_64