### PR TITLE
Patcherex.save_binary is no longer deprecated

### DIFF
--- a/examples/insert_instruction_patch/patch.py
+++ b/examples/insert_instruction_patch/patch.py
@@ -11,4 +11,4 @@ asm_str = """
 p.patches.append(InsertInstructionPatch(0x114d,asm_str))
 p.apply_patches()
 
-p.binfmt_tool.save_binary()
+p.save_binary()

--- a/examples/modify_function_patch/patch.py
+++ b/examples/modify_function_patch/patch.py
@@ -11,4 +11,4 @@ int add(int a, int b) {
 p.patches.append(ModifyFunctionPatch("add", new_add_func))
 
 p.apply_patches()
-p.binfmt_tool.save_binary("add_patched")
+p.save_binary("add_patched")

--- a/examples/multiple_patches/patch.py
+++ b/examples/multiple_patches/patch.py
@@ -26,4 +26,4 @@ p.patches.append(InsertInstructionPatch(0x11c1,asm_string))
 
 p.apply_patches()
 
-p.binfmt_tool.save_binary()
+p.save_binary()

--- a/src/patcherex2/patcherex.py
+++ b/src/patcherex2/patcherex.py
@@ -88,9 +88,9 @@ class Patcherex:
         """
         Applies all added patches to the binary. Call this when you have added all the patches you want.
         """
-        
+
         self.patches.sort(key=lambda x: self.patch_order.index(type(x)))
-        
+
         logger.debug(f"Applying patches: {self.patches}")
         for patch in self.patches:
             patch.apply(self)

--- a/src/patcherex2/patcherex.py
+++ b/src/patcherex2/patcherex.py
@@ -88,9 +88,13 @@ class Patcherex:
         """
         Applies all added patches to the binary. Call this when you have added all the patches you want.
         """
-
-        self.patches.sort(key=lambda x: self.patch_order.index(type(x)))
-
+        # TODO: sort patches properly
+        # self.patches.sort(key=lambda x: self.patch_order.index(type(x)))
+        self.patches.sort(
+            key=lambda x: not isinstance(
+                x, (ModifyDataPatch, InsertDataPatch, RemoveDataPatch)
+            )
+        )
         logger.debug(f"Applying patches: {self.patches}")
         for patch in self.patches:
             patch.apply(self)

--- a/src/patcherex2/patcherex.py
+++ b/src/patcherex2/patcherex.py
@@ -100,6 +100,6 @@ class Patcherex:
         """
         Save the patched binary to a file.
 
-        :param filename: Name of file to save to, defaults to None
+        :param filename: Name of file to save to, defaults to '<filename>.patched'
         """
         self.binfmt_tool.save_binary(filename)

--- a/src/patcherex2/patcherex.py
+++ b/src/patcherex2/patcherex.py
@@ -88,13 +88,9 @@ class Patcherex:
         """
         Applies all added patches to the binary. Call this when you have added all the patches you want.
         """
-        # TODO: sort patches properly
-        # self.patches.sort(key=lambda x: self.patch_order.index(type(x)))
-        self.patches.sort(
-            key=lambda x: not isinstance(
-                x, (ModifyDataPatch, InsertDataPatch, RemoveDataPatch)
-            )
-        )
+        
+        self.patches.sort(key=lambda x: self.patch_order.index(type(x)))
+        
         logger.debug(f"Applying patches: {self.patches}")
         for patch in self.patches:
             patch.apply(self)
@@ -106,7 +102,4 @@ class Patcherex:
 
         :param filename: Name of file to save to, defaults to None
         """
-        logger.warning(
-            "p.save_binary() is deprecated, use p.binfmt_tool.save_binary() instead."
-        )
         self.binfmt_tool.save_binary(filename)

--- a/tests/test_aarch64.py
+++ b/tests/test_aarch64.py
@@ -292,7 +292,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_arm.py
+++ b/tests/test_arm.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -314,7 +315,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_i386.py
+++ b/tests/test_i386.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -317,7 +318,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_mips.py
+++ b/tests/test_mips.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -303,7 +304,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_mips64.py
+++ b/tests/test_mips64.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -300,7 +301,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_mips64el.py
+++ b/tests/test_mips64el.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -300,7 +301,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_mipsel.py
+++ b/tests/test_mipsel.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -303,7 +304,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_ppc.py
+++ b/tests/test_ppc.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -200,7 +201,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_ppc64.py
+++ b/tests/test_ppc64.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -301,7 +302,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_ppc64le.py
+++ b/tests/test_ppc64le.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+
 import pytest
 
 from patcherex2 import *
@@ -301,7 +302,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(

--- a/tests/test_x86_64.py
+++ b/tests/test_x86_64.py
@@ -323,7 +323,7 @@ class Tests(unittest.TestCase):
             for patch in patches:
                 p.patches.append(patch)
             p.apply_patches()
-            p.binfmt_tool.save_binary(tmp_file)
+            p.save_binary(tmp_file)
             # os.system(f"readelf -hlS {tmp_file}")
 
             p = subprocess.Popen(


### PR DESCRIPTION
Updated all uses of binfmt_tool.save_binary in tests and examples to use save_binary