### PR TITLE
ci: skip the Patcherex2 install for lint and format jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,31 @@ on:
     - cron: '0 14 * * 1'  # Runs at 2 PM UTC every Monday
 
 jobs:
-  ci:
+  # Lint and format only read source files, so they skip the heavy
+  # Patcherex2 install (Ghidra, cross-toolchains, angr) entirely.
+  check:
     strategy:
       fail-fast: false
       matrix:
-        task: [test, lint, format, private-test]
+        task: [lint, format]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up Python 3
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install Packages
+        run: python3 -m pip install --upgrade ruff
+      - name: Run linter
+        if: matrix.task == 'lint'
+        run: python3 -m ruff check .
+      - name: Run formatter
+        if: matrix.task == 'format'
+        run: python3 -m ruff format . --check
+
+  test:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -19,24 +39,28 @@ jobs:
       - name: Install Patcherex2
         uses: ./.github/actions/install-patcherex2
       - name: Install Packages
-        run:  python3 -m pip install --upgrade pytest ruff
+        run: python3 -m pip install --upgrade pytest
       - name: Run pytest
-        if: matrix.task == 'test'
         run: python3 -m pytest
-      - name: Run formatter
-        if: matrix.task == 'format'
-        run: python3 -m ruff format . --check
-      - name: Run linter
-        if: matrix.task == 'lint'
-        run: python3 -m ruff check .
+
+  # Private tests need secrets unavailable to fork PRs, so this job is
+  # skipped on pull_request rather than installing and running nothing.
+  private-test:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Patcherex2
+        uses: ./.github/actions/install-patcherex2
+      - name: Install Packages
+        run: python3 -m pip install --upgrade pytest
       - name: Checkout Private Tests
-        if: matrix.task == 'private-test' && github.event_name != 'pull_request'
         uses: actions/checkout@v6
         with:
           repository: purseclab/patcherex2-private
           ssh-key: ${{ secrets.PRIVATE_TESTS_DEPLOY_KEY }}
           path: private
       - name: Run pytest for Private Tests
-        if: matrix.task == 'private-test' && github.event_name != 'pull_request'
         working-directory: ./private
         run: python3 -m pytest -q --no-summary


### PR DESCRIPTION
## Problem

The `Install Patcherex2` step had no `if:` guard, unlike every step below it. So all four legs of the matrix ran the full install, then each leg conditionally ran only its own command.

For the `lint` and `format` legs that meant paying for:

- ~13 cross-arch libc packages plus clang-15/lld-15
- an LLVM apt repo add plus clang-19/lld-19
- a Ghidra zip download and unzip
- `pip install -e .[all]`, which pulls in angr

…and then running `ruff`, which reads source files and never imports the package. None of that setup was reachable from either check.

`private-test` was worse: both of its steps were individually gated on `github.event_name != 'pull_request'`, so on PRs that leg did the entire install and then ran **nothing at all**.

## Change

Split the single four-leg matrix into three jobs:

- **`check`** — the `lint` + `format` matrix, with an explicit `actions/setup-python` and only `ruff` installed. Skips the heavy install entirely.
- **`test`** — unchanged behavior, keeps the full install.
- **`private-test`** — the `github.event_name != 'pull_request'` gate moves from the two steps up to the job, so it is skipped outright instead of installing and running nothing.

The `check` job needs its own `setup-python` because the install action was previously what set Python up.

## Behavior

Identical trigger conditions and identical commands throughout — the only differences are what gets installed before each check and where the `private-test` gate is evaluated.

## Verification

- `ruff format . --check` passes (99 files).
- Workflow YAML parses with the intended job/step structure and guards.
- Not yet exercised on GitHub Actions; this PR is the first real run.

## Notes

Two things I deliberately left out of scope:

1. **`check` no longer verifies that tests import cleanly.** Because it does not install the package, a broken import in a test file surfaces only in `test`. This is the correct split — `ruff` never imported the package before either — but `check` passing is a weaker signal than the old `format`/`lint` legs appeared to give.

2. **Pre-existing lint failures.** Running `ruff` 0.14.8 locally reports 14 `F403`/`F405` errors from `from .patches import *` in `src/patcherex2/patcherex.py`. These reproduce on unmodified `main`, so they are not introduced here. Since the workflow installs `--upgrade ruff` unpinned, CI will begin failing on them as soon as its runner resolves a version that flags them. Pinning `ruff` would make CI reproducible but is a separate decision from this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
